### PR TITLE
Add support for emphasized comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Features
 - Support [Syntastic](http://github.com/vim-syntastic/syntastic)
 - Better syntax highlight with [vim-javavscript](https://github.com/pangloss/vim-javascript)
 - Work fine with other various plugins: [tpope/vim-markdown](https://github.com/tpope/vim-markdown), [thinca/vim-zenspace](https://github.com/thinca/vim-zenspace), etc.
+- Emphasized comments via `g:iceberg_emphasize_comments=1`
 
 
 

--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -160,3 +160,9 @@ hi! link plugDash Comment
 hi! link plugMessage Special
 hi! link svssBraces Delimiter
 hi! link swiftIdentifier Normal
+
+
+if exists('g:iceberg_emphasize_comments') && g:iceberg_emphasize_comments
+    hi! Comment ctermfg=255 guifg=#ffffff
+endif
+


### PR DESCRIPTION
I personally prefer comments to be _more_ prominent than code, for a variety of reasons:

- Well written comments are the reader's guide through the code;
- Outdated comments are much more bothersome and thus less likely to be ignored;
- Commented out code is far more annoying and is more likely to be deleted.

_However,_ not everyone feels the same way, so I didn't make a wholesale change to the colorscheme, instead implementing a feature flag to make them more visible.

The flag is off by default, resulting in the colorscheme looking as it does now:

<img width="762" alt="iceberg-regular-comments" src="https://cloud.githubusercontent.com/assets/568543/22615413/3ee4ed00-ea49-11e6-8582-96f97bd2c80d.png">

Enabling it via

```viml
let g:iceberg_emphasize_comments=1
```

turns the comments white:

<img width="762" alt="iceberg-emphasize-comments" src="https://cloud.githubusercontent.com/assets/568543/22615418/51a547dc-ea49-11e6-8d51-a9b881a973c0.png">

Hopefully this seems like it could be helpful. I'm happy to maintain my own fork, but would obviously prefer the theme to support it out of the box, _and_ I'd like to give back. Thanks for such a great colorscheme! 🇦🇶