### PR TITLE
Add support for neovim terminal

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -181,3 +181,20 @@ hi! link typescriptIdentifier Statement
 hi! link typescriptMessage Normal
 hi! link typescriptNull Constant
 hi! link typescriptParens Normal
+
+let g:terminal_color_0 = "#161821"
+let g:terminal_color_1 = "#e27878"
+let g:terminal_color_2 = "#b4be82"
+let g:terminal_color_3 = "#d8e599"
+let g:terminal_color_4 = "#84a0c6"
+let g:terminal_color_5 = "#a093c7"
+let g:terminal_color_6 = "#89b8c2"
+let g:terminal_color_7 = "#c6c8d1"
+let g:terminal_color_8 = "#161821"
+let g:terminal_color_9 = "#e27878"
+let g:terminal_color_10 = "#b4be82"
+let g:terminal_color_11 = "#d8e599"
+let g:terminal_color_12 = "#84a0c6"
+let g:terminal_color_13 = "#a093c7"
+let g:terminal_color_14 = "#89b8c2"
+let g:terminal_color_15 = "#c6c8d1"


### PR DESCRIPTION
Adds the `g:terminal_color_*` variables that neovim uses in its `:terminal`. The variables are defined in the neovim documentation: https://neovim.io/doc/user/nvim_terminal_emulator.html#terminal-configuration. Closes #13.

Only the guifg colors from the preferred groups are used, with the exception of guibg for Normal. The colors were picked to roughly resemble the default terminal colors, and are repeated in two sets of eight. The specific source of the colors are:

0: Normal guibg
1: Error guifg
2: PreProc guifg
3: Todo guifg
4: Statement guifg
5: Constant guifg
6: Identifier guifg
7: Normal guifg
8: Normal guibg
9: Error guifg
10: PreProc guifg
11: Todo guifg
12: Statement guifg
13: Constant guifg
14: Identifier guifg
15: Normal guifg