### PR TITLE
Fix VertSplit reverse issue

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -82,7 +82,7 @@ hi! Title ctermfg=216 gui=NONE guifg=#e2a478
 hi! Todo ctermbg=234 ctermfg=150 guibg=#161821 guifg=#d8e599
 hi! Type ctermfg=109 gui=NONE guifg=#89b8c2
 hi! Underlined cterm=underline ctermfg=110 gui=underline guifg=#84a0c6 term=underline
-hi! VertSplit ctermbg=233 ctermfg=233 guibg=#0f1117 guifg=#0f1117
+hi! VertSplit cterm=NONE ctermbg=233 ctermfg=233 gui=NONE guibg=#0f1117 guifg=#0f1117
 hi! Visual ctermbg=236 guibg=#272c42
 hi! WildMenu ctermbg=255 ctermfg=234 guibg=#d4d5db guifg=#17171b
 hi! diffAdded ctermfg=150 guifg=#b4be82


### PR DESCRIPTION

<img width="899" alt="alacritty 2017-11-10 14-42-07" src="https://user-images.githubusercontent.com/546312/32644619-17529df0-c626-11e7-9de4-bdd780903045.png">

Somehow 'cterm=reverse' and 'gui=reverse' was specified to VertSplit.
Remove these unwilling features in iceberg.vim fix this issue.