### PR TITLE
Xresources in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,47 @@ For other environments
 - [Atom](https://github.com/cocopon/atom-iceberg-syntax/) by [cocopon](https://github.com/cocopon)
 - [Xcode](https://github.com/cocopon/xcode-iceberg) by [cocopon](https://github.com/cocopon)
 - [AppCode](https://github.com/Kuniwak/iceberg.icls) by [Kuniwak](https://github.com/Kuniwak)
+- Other : [terminal.sexy](http://terminal.sexy) provides configuration files for most Terminal
+emulators. Use this .Xresources file as Import and Export it for the emulator of your choice :
+```Xresources
+! special
+*.foreground:   #d2d4de
+*.background:   #161821
+*.cursorColor:  #d2d4de
 
+! black
+*.color0:       #161821
+*.color8:       #6b7089
 
+! red
+*.color1:       #e27878
+*.color9:       #e98989
+
+! green
+*.color2:       #b4be82
+*.color10:      #c0ca8e
+
+! yellow
+*.color3:       #e2a478
+*.color11:      #e9b189
+
+! blue
+*.color4:       #84a0c6
+*.color12:      #91acd1
+
+! magenta
+*.color5:       #a093c7
+*.color13:      #ada0d3
+
+! cyan
+*.color6:       #89b8c2
+*.color14:      #95c4ce
+
+! white
+*.color7:       #c6c8d1
+*.color15:      #d2d4de
+
+```
 
 
 License

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For other environments
 [terminal.sexy](http://terminal.sexy) provides configuration files for the 16 ANSI colors
 for many Terminal emulators. Use this .Xresources file as Import (Colorscheme used for
 the neovim terminal emulator) and Export it for the emulator of your choice :
-```Xresources
+```
 ! special
 *.foreground:   #d2d4de
 *.background:   #161821

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ For other environments
 - [Atom](https://github.com/cocopon/atom-iceberg-syntax/) by [cocopon](https://github.com/cocopon)
 - [Xcode](https://github.com/cocopon/xcode-iceberg) by [cocopon](https://github.com/cocopon)
 - [AppCode](https://github.com/Kuniwak/iceberg.icls) by [Kuniwak](https://github.com/Kuniwak)
-- Other : [terminal.sexy](http://terminal.sexy) provides configuration files for most Terminal
-emulators. Use this .Xresources file as Import and Export it for the emulator of your choice :
+- [Other](https://en.wikipedia.org/wiki/ANSI_escape_code#3.2F4_bit) :
+[terminal.sexy](http://terminal.sexy) provides configuration files for the 16 ANSI colors
+for many Terminal emulators. Use this .Xresources file as Import (Colorscheme used for
+the neovim terminal emulator) and Export it for the emulator of your choice :
 ```Xresources
 ! special
 *.foreground:   #d2d4de


### PR DESCRIPTION
I extracted the colors for neovim terminal emulator and put them in the README for simplicity.
I think that having just 1 Xresources file and providing ways to convert the files (I only know this website, if there are better/other I'd be happy to know them) is easier than maintaining different repositories with all configurations.