### PR TITLE
Change Neovim terminal black color

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -181,7 +181,7 @@ hi! link typescriptNull Constant
 hi! link typescriptParens Normal
 
 if has('nvim')
-  let g:terminal_color_0 = '#161821'
+  let g:terminal_color_0 = '#1D2030'
   let g:terminal_color_1 = '#e27878'
   let g:terminal_color_2 = '#b4be82'
   let g:terminal_color_3 = '#e2a478'


### PR DESCRIPTION
That's because due to conflict with Normal highlight group's background color. We can't distinguish them since they are the same.

## Before

> See background of `40m` column.

![image](https://user-images.githubusercontent.com/10108377/37268240-f1c4aea6-25d5-11e8-80b8-4f575f475913.png)

## After

![image](https://user-images.githubusercontent.com/10108377/37268262-052901ea-25d6-11e8-8cba-226585bf9368.png)
