### PR TITLE
Add support for vim-startify

### DIFF
--- a/src/iceberg.vim
+++ b/src/iceberg.vim
@@ -555,6 +555,17 @@ function! s:create_context() abort
         \   'guifg': g.comment_fg,
         \ }))
 
+  " [Startify](https://github.com/mhinz/vim-startify)
+  call add(links, pgmnt#hi#link('StartifyNumber', 'Special'))
+  call add(links, pgmnt#hi#link('StartifyFile', 'String'))
+  call add(links, pgmnt#hi#link('StartifyPath', 'Comment'))
+  call add(links, pgmnt#hi#link('StartifySlash', 'Comment'))
+  call add(links, pgmnt#hi#link('StartifyBracket', 'Comment'))
+  call add(links, pgmnt#hi#link('StartifyHeader', 'Constant'))
+  call add(links, pgmnt#hi#link('StartifyFooter', 'Constant'))
+  call add(links, pgmnt#hi#link('StartifySpecial', 'Normal'))
+  call add(links, pgmnt#hi#link('StartifySection', 'Statement'))
+
   " [SVSS](https://github.com/cocopon/svss.vim)
   call add(links, pgmnt#hi#link('svssBraces', 'Delimiter'))
   


### PR DESCRIPTION
After these small changes, here is the new look of **vim-startify** with **iceberg**:

<img width="621" alt="screen shot 2018-06-23 at 3 50 53 pm" src="https://user-images.githubusercontent.com/747855/41813597-83aed21e-76fe-11e8-9f9e-ead9a3d8ecba.png">

For comparison, here is the way it looked **before** the changes:

![image](https://user-images.githubusercontent.com/747855/41813603-a3e4aa2c-76fe-11e8-8756-afa4e163452c.png)
