### PR TITLE
Fix Terminal.app url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Building your own Iceberg
 
 For other environments
 ----------------------
-- [Terminal.app profile](http://cocopon.me/app/vim-iceberg/) by [cocopon](https://github.com/cocopon)
+- [Terminal.app profile](https://cocopon.github.io/iceberg.vim/) by [cocopon](https://github.com/cocopon)
 - [iTerm2](https://github.com/aseom/dotfiles/blob/master/osx/iterm2/iceberg.itermcolors) by [aseom](https://github.com/aseom)
 - [Atom](https://github.com/cocopon/atom-iceberg-syntax/) by [cocopon](https://github.com/cocopon)
 - [Xcode](https://github.com/cocopon/xcode-iceberg) by [cocopon](https://github.com/cocopon)


### PR DESCRIPTION
Terminal.app theme points to 404 
Is it possible to use navigation tags (e.g. `https://cocopon.github.io/iceberg.vim/#terminal.app` something like that) on your website to point directly to download section?