### PR TITLE
Restore Python built in function highlighting when using vim-python/python-syntax

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -121,7 +121,7 @@ hi! link htmlTag Statement
 hi! link jsonQuote Normal
 hi! link phpVarSelector Identifier
 hi! link pythonFunction Title
-hi! link pythonBuiltinFunc Title
+hi! link pythonBuiltinFunc Statement
 hi! link rubyDefine Statement
 hi! link rubyFunction Title
 hi! link rubyInterpolationDelimiter String

--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -121,6 +121,7 @@ hi! link htmlTag Statement
 hi! link jsonQuote Normal
 hi! link phpVarSelector Identifier
 hi! link pythonFunction Title
+hi! link pythonBuiltinFunc Title
 hi! link rubyDefine Statement
 hi! link rubyFunction Title
 hi! link rubyInterpolationDelimiter String


### PR DESCRIPTION

The syntax highlighting for python built-in functions disappeared for me a few commits back (I suspect, but have not confirmed that it was [this commit](https://github.com/cocopon/iceberg.vim/commit/b68890744dfe12673cef977f6f6d227fd949ae45)). 

This change restores it

I use https://github.com/vim-python/python-syntax with the `g:python_highlight_all` setting normally

##### Before

<img width="343" alt="screenshot 2018-08-07 07 57 26" src="https://user-images.githubusercontent.com/3429763/43774588-98867462-9a17-11e8-8d2a-5004de03f6c7.png">

##### After

<img width="310" alt="screenshot 2018-08-07 07 57 00" src="https://user-images.githubusercontent.com/3429763/43774587-98740746-9a17-11e8-9b3d-a11a90593627.png">