### PR TITLE
Add cterm=NONE to CursorLineNr

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -32,7 +32,7 @@ hi! CursorLine cterm=NONE ctermbg=235 guibg=#1e2132
 hi! Comment ctermfg=242 guifg=#6b7089
 hi! Constant ctermfg=140 guifg=#a093c7
 hi! Cursor ctermbg=252 ctermfg=234 guibg=#c6c8d1 guifg=#161821
-hi! CursorLineNr ctermbg=237 ctermfg=253 guibg=#2a3158 guifg=#cdd1e6
+hi! CursorLineNr cterm=NONE ctermbg=237 ctermfg=253 guibg=#2a3158 guifg=#cdd1e6
 hi! Delimiter ctermfg=252 guifg=#c6c8d1
 hi! DiffAdd ctermbg=29 ctermfg=158 guibg=#45493e guifg=#c0c5b9
 hi! DiffChange ctermbg=23 ctermfg=159 guibg=#384851 guifg=#b3c3cc


### PR DESCRIPTION
Recent vim has `CursorLineNr cterm=underline` as default setting.
https://github.com/vim/vim/blob/017ba07fa2cdc578245618717229444fd50c470d/src/highlight.c#L256

It adds unintended underline to the line number. In fact, similar issue is reported to stackoverflow.
https://stackoverflow.com/questions/58174536/vim-remove-underline-from-line-number

To avoid it, I added cterm=NONE to the corresponding setting.