### PR TITLE
light theme for airline and lightline

### DIFF
--- a/autoload/airline/themes/iceberg.vim
+++ b/autoload/airline/themes/iceberg.vim
@@ -3,16 +3,29 @@ set cpo&vim
 
 
 function! s:build_palette() abort
-  let col_base     = ['#3e445e', '#0f1117', 238, 233]
-  let col_edge     = ['#17171b', '#818596', 234, 245]
-  let col_error    = ['#161821', '#e27878', 234, 203]
-  let col_gradient = ['#6b7089', '#2e313f', 242, 236]
-  let col_nc       = ['#3e445e', '#0f1117', 238, 233]
-  let col_warning  = ['#161821', '#e2a478', 234, 216]
-  let col_insert   = ['#161821', '#84a0c6', 234, 110]
-  let col_replace  = ['#161821', '#e2a478', 234, 216]
-  let col_visual   = ['#161821', '#b4be82', 234, 150]
-  let col_red      = ['#e27878', '#161821', 203, 234]
+  if &background == 'light'
+    let col_base     = ['#8b98b6', '#cad0de', 244, 251]
+    let col_edge     = ['#e8e9ec', '#757ca3', 252, 243]
+    let col_error    = ['#e8e9ec', '#cc517a', 254, 125]
+    let col_gradient = ['#e8e9ec', '#9fa6c0', 252, 247]
+    let col_nc       = ['#8b98b6', '#cad0de', 244, 251]
+    let col_warning  = ['#e8e9ec', '#c57339', 254, 130]
+    let col_insert   = ['#e8e9ec', '#2d539e', 254, 25]
+    let col_replace  = ['#e8e9ec', '#c57339', 254, 130]
+    let col_visual   = ['#e8e9ec', '#668e3d', 254, 64]
+    let col_red      = ['#cc517a', '#e8e9ec', 125, 254]
+  else
+    let col_base     = ['#3e445e', '#0f1117', 238, 233]
+    let col_edge     = ['#17171b', '#818596', 234, 245]
+    let col_error    = ['#161821', '#e27878', 234, 203]
+    let col_gradient = ['#6b7089', '#2e313f', 242, 236]
+    let col_nc       = ['#3e445e', '#0f1117', 238, 233]
+    let col_warning  = ['#161821', '#e2a478', 234, 216]
+    let col_insert   = ['#161821', '#84a0c6', 234, 110]
+    let col_replace  = ['#161821', '#e2a478', 234, 216]
+    let col_visual   = ['#161821', '#b4be82', 234, 150]
+    let col_red      = ['#e27878', '#161821', 203, 234]
+  endif
 
   let p = {}
   let p.inactive = airline#themes#generate_color_map(

--- a/autoload/lightline/colorscheme/iceberg.vim
+++ b/autoload/lightline/colorscheme/iceberg.vim
@@ -11,18 +11,33 @@ function! s:build_palette() abort
         \ 'visual':   {},
         \ 'tabline':  {}}
 
-  let col_base     = ['#3e445e', '#0f1117', 238, 233]
-  let col_edge     = ['#17171b', '#818596', 234, 245]
-  let col_gradient = ['#6b7089', '#2e313f', 242, 236]
-  let col_nc       = ['#3e445e', '#0f1117', 238, 233]
-  let col_tabfill  = ['#3e445e', '#0f1117', 238, 233]
-  let col_normal   = ['#17171b', '#818596', 234, 245]
-  let col_error    = ['#161821', '#e27878', 234, 203]
-  let col_warning  = ['#161821', '#e2a478', 234, 216]
-  let col_insert   = ['#161821', '#84a0c6', 234, 110]
-  let col_replace  = ['#161821', '#e2a478', 234, 216]
-  let col_visual   = ['#161821', '#b4be82', 234, 150]
-  let col_tabsel   = ['#17171b', '#818596', 234, 245]
+  if &background == 'light'
+    let col_base     = ['#8b98b6', '#cad0de', 244, 251]
+    let col_edge     = ['#e8e9ec', '#757ca3', 252, 243]
+    let col_gradient = ['#e8e9ec', '#9fa6c0', 252, 247]
+    let col_nc       = ['#8b98b6', '#cad0de', 244, 251]
+    let col_tabfill  = ['#8b98b6', '#cad0de', 244, 251]
+    let col_normal   = ['#e8e9ec', '#757ca3', 252, 243]
+    let col_error    = ['#e8e9ec', '#cc517a', 254, 125]
+    let col_warning  = ['#e8e9ec', '#c57339', 254, 130]
+    let col_insert   = ['#e8e9ec', '#2d539e', 254, 25]
+    let col_replace  = ['#e8e9ec', '#c57339', 254, 130]
+    let col_visual   = ['#e8e9ec', '#668e3d', 254, 64]
+    let col_tabsel   = ['#e8e9ec', '#757ca3', 252, 243]
+  else
+    let col_base     = ['#3e445e', '#0f1117', 238, 233]
+    let col_edge     = ['#17171b', '#818596', 234, 245]
+    let col_gradient = ['#6b7089', '#2e313f', 242, 236]
+    let col_nc       = ['#3e445e', '#0f1117', 238, 233]
+    let col_tabfill  = ['#3e445e', '#0f1117', 238, 233]
+    let col_normal   = ['#17171b', '#818596', 234, 245]
+    let col_error    = ['#161821', '#e27878', 234, 203]
+    let col_warning  = ['#161821', '#e2a478', 234, 216]
+    let col_insert   = ['#161821', '#84a0c6', 234, 110]
+    let col_replace  = ['#161821', '#e2a478', 234, 216]
+    let col_visual   = ['#161821', '#b4be82', 234, 150]
+    let col_tabsel   = ['#17171b', '#818596', 234, 245]
+  endif
 
   let p.normal.middle = [
         \ col_base]


### PR DESCRIPTION
I see that you've started working on a light theme around 1.5 years ago, but never continued after creating the base vim colorscheme. I really want to see the light theme released, so here I am, doing what I can.

So far, I've added light colorscheme to airline and lightline.

It's would be perfectly usable right now, if not for the contrast between background color and cursor.
![qwe](https://user-images.githubusercontent.com/20600053/76206298-cc017a80-620c-11ea-8f69-a8219d953962.png)
<div align="center"><em>Dark and light themes side by side, for comparison</em></div>