### PR TITLE
Improve Rust syntax highlighting

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -5,7 +5,7 @@
 "
 " File:       iceberg.vim
 " Maintainer: cocopon <cocopon@me.com>
-" Modified:   2020-05-19 00:06+0300
+" Modified:   2020-07-20 14:00+0300
 " License:    MIT
 
 
@@ -133,9 +133,8 @@ if &background == 'light'
   hi! link rubyInterpolationDelimiter String
   hi! link rubySharpBang Comment
   hi! link rubyStringDelimiter String
-  hi! link rustFuncCall Special
+  hi! link rustFuncCall Normal
   hi! link rustFuncName Title
-  hi! link rustTrait Constant
   hi! link rustType Constant
   hi! link sassClass Special
   hi! link shFunction Normal
@@ -367,9 +366,8 @@ else
   hi! link rubyInterpolationDelimiter String
   hi! link rubySharpBang Comment
   hi! link rubyStringDelimiter String
-  hi! link rustFuncCall Special
+  hi! link rustFuncCall Normal
   hi! link rustFuncName Title
-  hi! link rustTrait Constant
   hi! link rustType Constant
   hi! link sassClass Special
   hi! link shFunction Normal

--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -5,7 +5,7 @@
 "
 " File:       iceberg.vim
 " Maintainer: cocopon <cocopon@me.com>
-" Modified:   2020-05-15 22:08+0900
+" Modified:   2020-05-19 00:06+0300
 " License:    MIT
 
 
@@ -133,6 +133,10 @@ if &background == 'light'
   hi! link rubyInterpolationDelimiter String
   hi! link rubySharpBang Comment
   hi! link rubyStringDelimiter String
+  hi! link rustFuncCall Special
+  hi! link rustFuncName Title
+  hi! link rustTrait Constant
+  hi! link rustType Constant
   hi! link sassClass Special
   hi! link shFunction Normal
   hi! link vimContinue Comment
@@ -363,6 +367,10 @@ else
   hi! link rubyInterpolationDelimiter String
   hi! link rubySharpBang Comment
   hi! link rubyStringDelimiter String
+  hi! link rustFuncCall Special
+  hi! link rustFuncName Title
+  hi! link rustTrait Constant
+  hi! link rustType Constant
   hi! link sassClass Special
   hi! link shFunction Normal
   hi! link vimContinue Comment

--- a/src/iceberg.vim
+++ b/src/iceberg.vim
@@ -464,9 +464,8 @@ function! s:create_colors(palette) abort
   call add(links, pgmnt#hi#link('rubyStringDelimiter', 'String'))
 
   " rust
-  call add(links, pgmnt#hi#link('rustFuncCall', 'Special'))
+  call add(links, pgmnt#hi#link('rustFuncCall', 'Normal'))
   call add(links, pgmnt#hi#link('rustFuncName', 'Title'))
-  call add(links, pgmnt#hi#link('rustTrait', 'Constant'))
   call add(links, pgmnt#hi#link('rustType', 'Constant'))
 
   " sass

--- a/src/iceberg.vim
+++ b/src/iceberg.vim
@@ -463,6 +463,12 @@ function! s:create_colors(palette) abort
   call add(links, pgmnt#hi#link('rubySharpBang', 'Comment'))
   call add(links, pgmnt#hi#link('rubyStringDelimiter', 'String'))
 
+  " rust
+  call add(links, pgmnt#hi#link('rustFuncCall', 'Special'))
+  call add(links, pgmnt#hi#link('rustFuncName', 'Title'))
+  call add(links, pgmnt#hi#link('rustTrait', 'Constant'))
+  call add(links, pgmnt#hi#link('rustType', 'Constant'))
+
   " sass
   call add(links, pgmnt#hi#link('sassClass', 'Special'))
 


### PR DESCRIPTION
Resolves #56 and generally improves Rust highlighting.

Code snippet more or less showcasing the changes:
![Code snippet](https://user-images.githubusercontent.com/20600053/82259949-0f8f0800-9965-11ea-83d7-6cdd36410ec7.png)
