### PR TITLE
[add] airline's terminal color

### DIFF
--- a/autoload/airline/themes/iceberg.vim
+++ b/autoload/airline/themes/iceberg.vim
@@ -72,6 +72,11 @@ function! s:build_palette() abort
   let p.replace.airline_warning = col_warning
   let p.visual.airline_warning = col_warning
 
+  " Terminal
+  let p.normal.airline_term = col_base
+  let p.insert.airline_term = col_base
+  let p.visual.airline_term = col_base
+
   return p
 endfunction
 

--- a/autoload/airline/themes/iceberg.vim
+++ b/autoload/airline/themes/iceberg.vim
@@ -48,6 +48,10 @@ function! s:build_palette() abort
         \ col_visual,
         \ col_gradient,
         \ col_base)
+  let p.terminal = airline#themes#generate_color_map(
+        \ col_insert,
+        \ col_gradient,
+        \ col_base)
 
   " Accents
   let p.accents = {

--- a/autoload/airline/themes/iceberg.vim
+++ b/autoload/airline/themes/iceberg.vim
@@ -74,7 +74,7 @@ function! s:build_palette() abort
 
   " Terminal
   let p.normal.airline_term = col_base
-  let p.insert.airline_term = col_base
+  let p.terminal.airline_term = col_base
   let p.visual.airline_term = col_base
 
   return p


### PR DESCRIPTION
Hello @cocopon .
Thanks for creating great Vim's colorscheme.
I love this colorscheme!!

By the way, I've updated the color scheme in the terminal section of the vim-airline.
This is expected to improve the user interface.
This uses the same green color scheme as the insert mode color scheme. 

## before

![iceberg_before](https://user-images.githubusercontent.com/36619465/86950796-999c6580-c18b-11ea-9de6-1f71da5e350f.gif)

## after

![iceberg](https://user-images.githubusercontent.com/36619465/86950804-9bfebf80-c18b-11ea-9d81-ae56c404643d.gif)

Could you check this PR?

