### PR TITLE
match SpecialKey to Comment instead of NonText

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -41,7 +41,12 @@ if &background == 'light'
   hi WarningMsg ctermbg=254 ctermfg=125 guibg=#e8e9ec guifg=#cc517a
   hi EndOfBuffer ctermbg=254 ctermfg=251 guibg=#e8e9ec guifg=#cbcfda
   hi NonText ctermbg=254 ctermfg=251 guibg=#e8e9ec guifg=#cbcfda
-  hi SpecialKey ctermfg=244 guifg=#8389a3
+  if has('nvim')
+    hi SpecialKey ctermfg=244 guifg=#8389a3
+    hi Whitespace ctermbg=254 ctermfg=251 guibg=#e8e9ec guifg=#cbcfda
+  else
+    hi SpecialKey ctermbg=254 ctermfg=251 guibg=#e8e9ec guifg=#cbcfda
+  endif
   hi Folded ctermbg=253 ctermfg=243 guibg=#dcdfe7 guifg=#788098
   hi FoldColumn ctermbg=253 ctermfg=248 guibg=#dcdfe7 guifg=#9fa7bd
   hi Function ctermfg=25 guifg=#2d539e
@@ -274,7 +279,12 @@ else
   hi WarningMsg ctermbg=234 ctermfg=203 guibg=#161821 guifg=#e27878
   hi EndOfBuffer ctermbg=234 ctermfg=236 guibg=#161821 guifg=#242940
   hi NonText ctermbg=234 ctermfg=236 guibg=#161821 guifg=#242940
-  hi SpecialKey ctermfg=242 guifg=#6b7089
+  if has('nvim')
+    hi SpecialKey ctermfg=242 guifg=#6b7089
+    hi Whitespace ctermbg=234 ctermfg=236 guibg=#161821 guifg=#242940
+  else
+    hi SpecialKey ctermbg=234 ctermfg=236 guibg=#161821 guifg=#242940
+  endif
   hi Folded ctermbg=235 ctermfg=245 guibg=#1e2132 guifg=#686f9a
   hi FoldColumn ctermbg=235 ctermfg=239 guibg=#1e2132 guifg=#444b71
   hi Function ctermfg=110 guifg=#84a0c6

--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -41,7 +41,7 @@ if &background == 'light'
   hi WarningMsg ctermbg=254 ctermfg=125 guibg=#e8e9ec guifg=#cc517a
   hi EndOfBuffer ctermbg=254 ctermfg=251 guibg=#e8e9ec guifg=#cbcfda
   hi NonText ctermbg=254 ctermfg=251 guibg=#e8e9ec guifg=#cbcfda
-  hi SpecialKey ctermbg=254 ctermfg=251 guibg=#e8e9ec guifg=#cbcfda
+  hi SpecialKey ctermfg=244 guifg=#8389a3
   hi Folded ctermbg=253 ctermfg=243 guibg=#dcdfe7 guifg=#788098
   hi FoldColumn ctermbg=253 ctermfg=248 guibg=#dcdfe7 guifg=#9fa7bd
   hi Function ctermfg=25 guifg=#2d539e
@@ -274,7 +274,7 @@ else
   hi WarningMsg ctermbg=234 ctermfg=203 guibg=#161821 guifg=#e27878
   hi EndOfBuffer ctermbg=234 ctermfg=236 guibg=#161821 guifg=#242940
   hi NonText ctermbg=234 ctermfg=236 guibg=#161821 guifg=#242940
-  hi SpecialKey ctermbg=234 ctermfg=236 guibg=#161821 guifg=#242940
+  hi SpecialKey ctermfg=242 guifg=#6b7089
   hi Folded ctermbg=235 ctermfg=245 guibg=#1e2132 guifg=#686f9a
   hi FoldColumn ctermbg=235 ctermfg=239 guibg=#1e2132 guifg=#444b71
   hi Function ctermfg=110 guifg=#84a0c6


### PR DESCRIPTION
The `SpecialKey` highlight group has really low contrast with the background. Unlike `NonText` which is decorative in vim's UI, `SpecialKey` is actually part of the file being edited. I personally run into the problem a lot when editing vim macros or `:s` replacements.

This PR proposes replacing the highlight of `SpecialKey` to match that of `Comment` instead, which makes it readable while keeping the colors relatively muted.

Before/After screenshot:

![special-key](https://user-images.githubusercontent.com/624737/101828112-f9ee5500-3ae5-11eb-80c1-41b322183dc6.png)
