### PR TITLE
fix some typescript bg colors in hover window

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -5,7 +5,7 @@
 "
 " File:       iceberg.vim
 " Maintainer: cocopon <cocopon@me.com>
-" Modified:   2020-12-25 11:57+0900
+" Modified:   2021-11-11 11:53-0500
 " License:    MIT
 
 
@@ -361,16 +361,16 @@ hi! link StartifySlash Comment
 hi! link StartifySpecial Normal
 hi! link svssBraces Delimiter
 hi! link swiftIdentifier Normal
-hi! link typescriptAjaxMethods Normal
-hi! link typescriptBraces Normal
-hi! link typescriptEndColons Normal
+hi! link typescriptAjaxMethods Noise
+hi! link typescriptBraces jsFuncBraces
+hi! link typescriptEndColons Noise
 hi! link typescriptFuncKeyword Statement
 hi! link typescriptGlobalObjects Statement
-hi! link typescriptHtmlElemProperties Normal
+hi! link typescriptHtmlElemProperties Noise
 hi! link typescriptIdentifier Statement
-hi! link typescriptMessage Normal
-hi! link typescriptNull Constant
-hi! link typescriptParens Normal
+hi! link typescriptMessage Noise
+hi! link typescriptNull jsNull
+hi! link typescriptParens jsParens
 
 if !has('nvim')
   hi! link SpecialKey Whitespace

--- a/src/iceberg.vim
+++ b/src/iceberg.vim
@@ -764,16 +764,16 @@ function! s:create_links() abort
   call add(links, pgmnt#hi#link('swiftIdentifier', 'Normal'))
 
   " [typescript-vim](https://github.com/leafgarland/typescript-vim)
-  call add(links, pgmnt#hi#link('typescriptAjaxMethods', 'Normal'))
-  call add(links, pgmnt#hi#link('typescriptBraces', 'Normal'))
-  call add(links, pgmnt#hi#link('typescriptEndColons', 'Normal'))
+  call add(links, pgmnt#hi#link('typescriptAjaxMethods', 'Noise'))
+  call add(links, pgmnt#hi#link('typescriptBraces', 'jsFuncBraces'))
+  call add(links, pgmnt#hi#link('typescriptEndColons', 'Noise'))
   call add(links, pgmnt#hi#link('typescriptFuncKeyword', 'Statement'))
   call add(links, pgmnt#hi#link('typescriptGlobalObjects', 'Statement'))
-  call add(links, pgmnt#hi#link('typescriptHtmlElemProperties', 'Normal'))
+  call add(links, pgmnt#hi#link('typescriptHtmlElemProperties', 'Noise'))
   call add(links, pgmnt#hi#link('typescriptIdentifier', 'Statement'))
-  call add(links, pgmnt#hi#link('typescriptMessage', 'Normal'))
-  call add(links, pgmnt#hi#link('typescriptNull', 'Constant'))
-  call add(links, pgmnt#hi#link('typescriptParens', 'Normal'))
+  call add(links, pgmnt#hi#link('typescriptMessage', 'Noise'))
+  call add(links, pgmnt#hi#link('typescriptNull', 'jsNull'))
+  call add(links, pgmnt#hi#link('typescriptParens', 'jsParens'))
   " }}}
 
   return links


### PR DESCRIPTION
When hovering, as with neovim's LSP hover, these groups are displayed with a background color other than Normal's.  Because of this, linking to Normal results in the wrong background color.  To get around that, I removed the Normal links for typescript groups and linked them to vim-javascript groups instead.

I'm pretty sure there's a better approach that doesn't rely on vim-javascript, I'm just not savvy enough with colorschemes to know what that approach is.

Before:

![Screenshot from 2021-11-11 11-43-00](https://user-images.githubusercontent.com/364615/141337988-865deb3c-c575-4ac1-afde-c3a9022ee20d.png)

After:

![Screenshot from 2021-11-11 11-42-14](https://user-images.githubusercontent.com/364615/141338029-df3741df-5ff2-4acc-8cd0-8ea89c1ff701.png)