### PR TITLE
Add support for iTerm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Creator of Iceberg talked about how to create your lovely color scheme in
   by [gkeep](https://github.com/gkeep)
 - [alacritty](https://github.com/alacritty/alacritty/wiki/Color-schemes#iceberg)
   by [connorlay](https://github.com/connorlay)
+- [iTerm2](https://github.com/YusukeSano/iterm2-iceberg)
+  by [YusukeSano](https://github.com/YusukeSano)
 
 NOTE: [terminal.sexy][terminal-sexy] provides configuration files for
 the 16 ANSI colors for many terminal emulators (e.g. GNOME Terminal, iTerm2,


### PR DESCRIPTION
The [terminal.sexy](https://terminal.sexy/) provides iTerm2 color schemes via [.Xresources](https://gist.github.com/cocopon/1d481941907d12db7a0df2f8806cfd41), but some settings, such as Selection and Link, are not supported.

So I created a complete [Icebreg for iTerm2](https://github.com/YusukeSano/iterm2-iceberg) and added port links.

|Before|After|
|---|---|
|![](https://user-images.githubusercontent.com/54178415/185724272-8c6d1fe3-224d-4a68-b9f3-44ac307fbbce.png)|![](https://user-images.githubusercontent.com/54178415/185724276-36fd76d4-e7f5-452b-805d-275f2241d61b.png)|
<br>

This also supports separate color settings for light & dark modes, which will be added in the latest beta (3.5) of iTerm2.

|Light|Dark|
|---|---|
|![](https://user-images.githubusercontent.com/54178415/185724320-e7a20db3-6a20-4184-ab63-18660948f734.png)|![](https://user-images.githubusercontent.com/54178415/185724322-31946aed-d7d7-4ec8-8fbb-50abf21ddf58.png)|