### PR TITLE
Fix SpecialKey linking issue for :dig visibility

### DIFF
--- a/colors/iceberg.vim
+++ b/colors/iceberg.vim
@@ -5,7 +5,7 @@
 "
 " File:       iceberg.vim
 " Maintainer: cocopon <cocopon@me.com>
-" Modified:   2022-11-16 22:13+0900
+" Modified:   2024-03-14 07:58-0400
 " License:    MIT
 
 
@@ -497,6 +497,8 @@ if has('nvim-0.8')
   hi! link @variable.builtin TSVariableBuiltin
 endif
 
-if !has('nvim')
+let g:iceberg_specialkey_ws = get(g:, 'iceberg_specialkey_ws', has('nvim') ? 0 : 1)
+
+if iceberg_specialkey_ws
   hi! link SpecialKey Whitespace
 endif

--- a/src/template.vim
+++ b/src/template.vim
@@ -44,6 +44,8 @@ if has('nvim-0.8')
   {{ neovim_08_links }}
 endif
 
-if !has('nvim')
+let g:iceberg_specialkey_ws = get(g:, 'iceberg_specialkey_ws', has('nvim') ? 0 : 1)
+
+if iceberg_specialkey_ws
   hi! link SpecialKey Whitespace
 endif


### PR DESCRIPTION
When using diacritics the colorscheme makes it hard to read the digraph symbols this is due to the `hi! link SpecialKey Whitespace' setting that is implemented when not in nvim. I don't know the reason for this being in so I added a configuration item to tweak this behavior. It is fully backwards compatible.

Closes: #114